### PR TITLE
Update name and link for `Beginning Android & Kotlin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learning the Basics of the Kotlin Language
 
-This repo contains all the downloadable materials and projects associated with the **Learning the Basics of the Kotlin Language** module in the **[Learn the Kotlin Language](https://www.kodeco.com/android/paths/learn-kotlin-language)**. This course is part of [Kotlin Essentials](https://www.kodeco.com/android/programs/kotlin-essentials), which you can take as on-demand bootcamp from [Kodeco](https://www.kodeco.com).
+This repo contains all the downloadable materials and projects associated with the **Learning the Basics of the Kotlin Language** module in the **[Learn the Kotlin Language](https://www.kodeco.com/android/paths/learn-kotlin-language)**. This course is part of [Beginning Android & Kotlin](https://www.kodeco.com/android/programs/beginning-android), which you can take as on-demand bootcamp from [Kodeco](https://www.kodeco.com).
 
 Each edition has its own branch, named `versions/[VERSION]`. The default branch for this repo is for the most recent edition.
 


### PR DESCRIPTION
Update the name and link for `Kotlin Essentials` (Current the link is not found) with `Beginning Android & Kotlin`.